### PR TITLE
fix: issue #19 always return browser to pool

### DIFF
--- a/src/services/image-render.service.ts
+++ b/src/services/image-render.service.ts
@@ -55,9 +55,8 @@ export class ImageRenderService implements OnApplicationShutdown {
       }
     }
 
-    let browser;
+    let browser = await this.browserPool.acquire();
     try {
-      browser = await this.browserPool.acquire();
       const page = await browser.newPage({
         viewport: {
           width: config.viewPortWidth,
@@ -79,9 +78,7 @@ export class ImageRenderService implements OnApplicationShutdown {
       }
       return image ?? false;
     } finally {
-      if (browser) {
-        await this.browserPool.release(browser);
-      }
+      await this.browserPool.release(browser);
     }
   }
 

--- a/src/services/image-render.service.ts
+++ b/src/services/image-render.service.ts
@@ -55,7 +55,7 @@ export class ImageRenderService implements OnApplicationShutdown {
       }
     }
 
-    let browser = await this.browserPool.acquire();
+    const browser = await this.browserPool.acquire();
     try {
       const page = await browser.newPage({
         viewport: {

--- a/src/services/image-render.service.ts
+++ b/src/services/image-render.service.ts
@@ -55,29 +55,34 @@ export class ImageRenderService implements OnApplicationShutdown {
       }
     }
 
-    const browser = await this.browserPool.acquire();
-    const page = await browser.newPage({
-      viewport: {
-        width: config.viewPortWidth,
-        height: config.viewPortHeight,
-      },
-      isMobile: config.isMobile,
-      colorScheme: config.isDarkMode ? "dark" : "light",
-      deviceScaleFactor: config.deviceScaleFactor,
-    });
-
-    let image: Buffer;
-
+    let browser;
     try {
-      await page.goto(url, this.NAV_OPTIONS);
-      const screenshot = await page.screenshot({ fullPage: config.isFullPage });
-      image = await this.resize(screenshot, config.width, config.height);
-      await this.browserPool.release(browser);
-    } finally {
-      await page.close();
-    }
+      browser = await this.browserPool.acquire();
+      const page = await browser.newPage({
+        viewport: {
+          width: config.viewPortWidth,
+          height: config.viewPortHeight,
+        },
+        isMobile: config.isMobile,
+        colorScheme: config.isDarkMode ? "dark" : "light",
+        deviceScaleFactor: config.deviceScaleFactor,
+      });
 
-    return image ?? false;
+      let image: Buffer;
+
+      try {
+        await page.goto(url, this.NAV_OPTIONS);
+        const screenshot = await page.screenshot({ fullPage: config.isFullPage });
+        image = await this.resize(screenshot, config.width, config.height);
+      } finally {
+        await page.close();
+      }
+      return image ?? false;
+    } finally {
+      if (browser) {
+        await this.browserPool.release(browser);
+      }
+    }
   }
 
   private async resize(image, width: number, height: number): Promise<Buffer> {


### PR DESCRIPTION
I wrapped the lifetime of the acquired `browser` from the `browserPool` in a `try/finally` so if any error occurs the `browser` is returned to the `browserPool`.

Following the README I couldn't get the code to compile using `npm` to pull down the packages/build. I noticed the git logs mentioned `pnpm` so tried that and everything compiled/ran and appears to work as before.